### PR TITLE
Fix bazel config for azure/attestation

### DIFF
--- a/scp/cc/azure/attestation/BUILD.bazel
+++ b/scp/cc/azure/attestation/BUILD.bazel
@@ -20,8 +20,10 @@ cc_library(
     name = "aci_attestation_lib",
     srcs = glob(
         [
-            "**/*.cc",
-            "**/*.h",
+            "json_attestation_report.cc",
+            "json_attestation_report.h",
+            "security_context_fetcher.cc",
+            "security_context_fetcher.h"
         ],
     ),
     deps = [

--- a/scp/cc/azure/attestation/BUILD.bazel
+++ b/scp/cc/azure/attestation/BUILD.bazel
@@ -23,7 +23,7 @@ cc_library(
             "json_attestation_report.cc",
             "json_attestation_report.h",
             "security_context_fetcher.cc",
-            "security_context_fetcher.h"
+            "security_context_fetcher.h",
         ],
     ),
     deps = [


### PR DESCRIPTION
We used to include all files in the library, but when a utility to print snp info was added this also gets included and the main() function definition messes with bazel tests