### PR TITLE
Fix bazel config for azure/attestation

### DIFF
--- a/scp/cc/azure/attestation/BUILD.bazel
+++ b/scp/cc/azure/attestation/BUILD.bazel
@@ -20,8 +20,10 @@ cc_library(
     name = "aci_attestation_lib",
     srcs = glob(
         [
-            "**/*.cc",
-            "**/*.h",
+            "json_attestation_report.cc",
+            "json_attestation_report.h",
+            "security_context_fetcher.cc",
+            "security_context_fetcher.h",
         ],
     ),
     deps = [


### PR DESCRIPTION
The bazel config includes all files, but since we've added utilities such as `print_snp_json` we should only include the code needed

This meant we weren't running tests we expected to run