### PR TITLE
Add AzureRoleCredentialsProvider

### DIFF
--- a/scp/cc/cpio/client_providers/role_credentials_provider/src/BUILD.bazel
+++ b/scp/cc/cpio/client_providers/role_credentials_provider/src/BUILD.bazel
@@ -25,7 +25,7 @@ cc_library(
                 "//scp/cc/cpio/client_providers/role_credentials_provider/src/aws:aws_role_credentials_provider_lib",
             ],
             "//:azure_platform": [
-                "//scp/cc/cpio/client_providers/role_credentials_provider/src/gcp:gcp_role_credentials_provider_lib",
+                "//scp/cc/cpio/client_providers/role_credentials_provider/src/azure:azure_role_credentials_provider_lib",
             ],
             "//:gcp_platform": [
                 "//scp/cc/cpio/client_providers/role_credentials_provider/src/gcp:gcp_role_credentials_provider_lib",

--- a/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/BUILD.bazel
+++ b/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/BUILD.bazel
@@ -1,0 +1,44 @@
+# Portions Copyright (c) Microsoft Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//scp/cc:scp_internal_pkg"])
+
+cc_library(
+    name = "azure_role_credentials_provider_lib",
+    srcs = [
+        "//scp/cc/cpio/client_providers/interface:role_credentials_provider_interface.h",
+        "//scp/cc/cpio/client_providers/role_credentials_provider/src/azure:azure_role_credentials_provider_srcs",
+    ],
+    deps = [
+        "//scp/cc:cc_base_include_dir",
+        "//scp/cc/core/interface:interface_lib",
+        "//scp/cc/cpio/client_providers/instance_client_provider/src/azure:azure_instance_client_provider_lib",
+        "//scp/cc/public/cpio/interface:type_def",
+    ],
+)
+
+exports_files([
+    "azure_role_credentials_provider.h",
+    "azure_role_credentials_provider.cc",
+])
+
+filegroup(
+    name = "azure_role_credentials_provider_srcs",
+    srcs = [
+        ":azure_role_credentials_provider.cc",
+        ":azure_role_credentials_provider.h",
+    ],
+)

--- a/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.cc
+++ b/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.cc
@@ -1,0 +1,57 @@
+/*
+ * Portions Copyright (c) Microsoft Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "azure_role_credentials_provider.h"
+
+#include <memory>
+
+#include "cpio/client_providers/interface/role_credentials_provider_interface.h"
+
+using google::scp::core::AsyncContext;
+using google::scp::core::ExecutionResult;
+using google::scp::core::FailureExecutionResult;
+using google::scp::core::SuccessExecutionResult;
+
+namespace google::scp::cpio::client_providers {
+ExecutionResult AzureRoleCredentialsProvider::Init() noexcept {
+  return SuccessExecutionResult();
+}
+
+ExecutionResult AzureRoleCredentialsProvider::Run() noexcept {
+  return SuccessExecutionResult();
+}
+
+ExecutionResult AzureRoleCredentialsProvider::Stop() noexcept {
+  return SuccessExecutionResult();
+}
+
+ExecutionResult AzureRoleCredentialsProvider::GetRoleCredentials(
+    core::AsyncContext<GetRoleCredentialsRequest, GetRoleCredentialsResponse>&
+        get_credentials_context) noexcept {
+  return FailureExecutionResult(SC_UNKNOWN);
+}
+
+std::shared_ptr<RoleCredentialsProviderInterface>
+RoleCredentialsProviderFactory::Create(
+    const std::shared_ptr<RoleCredentialsProviderOptions>& options,
+    const std::shared_ptr<InstanceClientProviderInterface>&
+        instance_client_provider,
+    const std::shared_ptr<core::AsyncExecutorInterface>& cpu_async_executor,
+    const std::shared_ptr<core::AsyncExecutorInterface>&
+        io_async_executor) noexcept {
+  return std::make_shared<AzureRoleCredentialsProvider>();
+}
+}  // namespace google::scp::cpio::client_providers

--- a/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.cc
+++ b/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.cc
@@ -41,6 +41,7 @@ ExecutionResult AzureRoleCredentialsProvider::Stop() noexcept {
 ExecutionResult AzureRoleCredentialsProvider::GetRoleCredentials(
     core::AsyncContext<GetRoleCredentialsRequest, GetRoleCredentialsResponse>&
         get_credentials_context) noexcept {
+  // Not implemented.
   return FailureExecutionResult(SC_UNKNOWN);
 }
 

--- a/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.h
+++ b/scp/cc/cpio/client_providers/role_credentials_provider/src/azure/azure_role_credentials_provider.h
@@ -1,0 +1,38 @@
+/*
+ * Portions Copyright (c) Microsoft Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CPIO_CLIENT_PROVIDERS_ROLE_CREDENTIALS_PROVIDER_SRC_AZURE_AZURE_ROLE_CREDENTIALS_PROVIDER_H_
+#define CPIO_CLIENT_PROVIDERS_ROLE_CREDENTIALS_PROVIDER_SRC_AZURE_AZURE_ROLE_CREDENTIALS_PROVIDER_H_
+
+#include "cpio/client_providers/interface/role_credentials_provider_interface.h"
+
+namespace google::scp::cpio::client_providers {
+
+class AzureRoleCredentialsProvider : public RoleCredentialsProviderInterface {
+ public:
+  core::ExecutionResult Init() noexcept override;
+
+  core::ExecutionResult Run() noexcept override;
+
+  core::ExecutionResult Stop() noexcept override;
+
+  core::ExecutionResult GetRoleCredentials(
+      core::AsyncContext<GetRoleCredentialsRequest, GetRoleCredentialsResponse>&
+          get_credentials_context) noexcept override;
+};
+}  // namespace google::scp::cpio::client_providers
+
+#endif  // CPIO_CLIENT_PROVIDERS_ROLE_CREDENTIALS_PROVIDER_SRC_AZURE_AZURE_ROLE_CREDENTIALS_PROVIDER_H_


### PR DESCRIPTION
Added AzureRoleCredentialsProvider. It just returns "not implemented" which is described as `FailureExecutionResult(SC_UNKNOWN)` as the convention in the code base.

The actual implementation only exists for AWS. From what I learned from the AWS  implementation, `RoleCredentialsProvider` is similar to `AuthTokenProvider` in a sense that the both get access tokens.

| **Class**           | **Authentication Method (AWS)** | **Azure Equivalent** | **Used for (AWS)**                     |
|------------------------|----------------------------------|----------------------|----------------------------------|
| RoleCredentialsProvider | STS                              | Entra                | KMS access                       |
| AuthTokenProvider      | IMDS                             | Managed Identity     | Getting metadata (InstanceClientProvider) |


Comparison between STS and IMDS (maybe there is a better document for that): https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html

So I think we should implement `RoleCredentialsProvider ` once we need to use Entra, but as long as Managed Identity is enough we don't need one.