### PR TITLE
Fix copyright

### DIFF
--- a/src/cpio/client_providers/cloud_initializer/azure/no_op_initializer.cc
+++ b/src/cpio/client_providers/cloud_initializer/azure/no_op_initializer.cc
@@ -1,5 +1,5 @@
 /*
- * Portions Copyright (c) Microsoft Corporation
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
One of the TODOs from https://github.com/privacysandbox/data-plane-shared-libraries/pull/1

```
Fix license under cloud_initializer/src/azure/ directory. We copied the gcp implementation, but accidentally added the Microsoft copyright. We made this PR without the fix because testing is expensive with our internal test infrastructure at this moment. We'll fix them within this PR if there is other change that needs to be made before merging.
```

CI: https://github.com/microsoft/privacy-sandbox-dev/actions/runs/9547669407