### PR TITLE
Changes for managed identity

### DIFF
--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
@@ -59,8 +59,9 @@ constexpr char kMetadataHeaderValue[] = "true";
 // Local IDP for Managed Identity.
 // https://learn.microsoft.com/en-us/azure/container-instances/container-instances-managed-identity
 constexpr char kDefaultGetTokenUrl[] =
-    "http://169.254.169.254/metadata/identity/oauth2/"
-    "token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com";
+    "http://169.254.169.254/metadata/identity/oauth2/token";
+constexpr char kGetTokenQuery[] =
+    "?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F";
 constexpr char kGetTokenUrlEnvVar[] = "AZURE_BA_PARAM_GET_TOKEN_URL";
 constexpr char kJsonAccessTokenKey[] = "access_token";
 constexpr char kJsonTokenExpiryKey[] = "expires_in";
@@ -86,9 +87,10 @@ AzureAuthTokenProvider::AzureAuthTokenProvider(
     : http_client_(http_client), get_token_url_() {
   const char* value_from_env = std::getenv(kGetTokenUrlEnvVar);
   if (value_from_env) {
-    get_token_url_ = value_from_env;
+    get_token_url_ = std::string(value_from_env) + std::string(kGetTokenQuery);
   } else {
-    get_token_url_ = kDefaultGetTokenUrl;
+    get_token_url_ =
+        std::string(kDefaultGetTokenUrl) + std::string(kGetTokenQuery);
   }
 }
 

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
@@ -60,8 +60,7 @@ constexpr char kMetadataHeaderValue[] = "true";
 // https://learn.microsoft.com/en-us/azure/container-instances/container-instances-managed-identity
 constexpr char kDefaultGetTokenUrl[] =
     "http://169.254.169.254/metadata/identity/oauth2/"
-    "token?api-version=2018-02-01&resource=https%3A%2F%2Fprivacysandboxkms."
-    "azure.net";
+    "token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com";
 constexpr char kGetTokenUrlEnvVar[] = "AZURE_BA_PARAM_GET_TOKEN_URL";
 constexpr char kJsonAccessTokenKey[] = "access_token";
 constexpr char kJsonTokenExpiryKey[] = "expires_in";

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
@@ -186,7 +186,8 @@ void AzureAuthTokenProvider::OnGetSessionTokenCallback(
       auto result = RetryExecutionResult(
           SC_AZURE_INSTANCE_AUTHORIZER_PROVIDER_BAD_SESSION_TOKEN);
       SCP_ERROR_CONTEXT(kAzureAuthTokenProvider, get_token_context, result,
-                        "The value for filed expires_in is invalid.");
+                        "The string value for field expires_in cannot be "
+                        "parsed as an integer.");
       get_token_context.result = result;
       get_token_context.Finish();
       return;
@@ -195,7 +196,7 @@ void AzureAuthTokenProvider::OnGetSessionTokenCallback(
     auto result = RetryExecutionResult(
         SC_AZURE_INSTANCE_AUTHORIZER_PROVIDER_BAD_SESSION_TOKEN);
     SCP_ERROR_CONTEXT(kAzureAuthTokenProvider, get_token_context, result,
-                      "The value for filed expires_in is invalid.");
+                      "The value for field expires_in is invalid.");
     get_token_context.result = result;
     get_token_context.Finish();
     return;

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
@@ -64,18 +64,16 @@ constexpr char kDefaultGetTokenUrl[] =
 constexpr char kGetTokenUrlEnvVar[] = "AZURE_BA_PARAM_GET_TOKEN_URL";
 constexpr char kJsonAccessTokenKey[] = "access_token";
 constexpr char kJsonTokenExpiryKey[] = "expires_in";
-constexpr char kJsonTokenExtendedExpiryKey[] = "ext_expires_in";
 constexpr char kJsonTokenTypeKey[] = "token_type";
 
 // Returns a pair of iterators - one to the beginning, one to the end.
 const auto& GetRequiredJWTComponents() {
-  static char const* components[4];
+  static char const* components[3];
   using iterator_type = decltype(std::cbegin(components));
   static std::pair<iterator_type, iterator_type> iterator_pair = []() {
     components[0] = kJsonAccessTokenKey;
     components[1] = kJsonTokenExpiryKey;
-    components[2] = kJsonTokenExtendedExpiryKey;
-    components[3] = kJsonTokenTypeKey;
+    components[2] = kJsonTokenTypeKey;
     return std::make_pair(std::cbegin(components), std::cend(components));
   }();
   return iterator_pair;

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc
@@ -169,9 +169,10 @@ void AzureAuthTokenProvider::OnGetSessionTokenCallback(
   }
   get_token_context.response = std::make_shared<GetSessionTokenResponse>();
 
-  uint64_t expiry_seconds = json_response[kJsonTokenExpiryKey].get<uint64_t>();
+  std::string expiry_seconds =
+      json_response[kJsonTokenExpiryKey].get<std::string>();
   get_token_context.response->token_lifetime_in_seconds =
-      std::chrono::seconds(expiry_seconds);
+      std::chrono::seconds(std::stoi(expiry_seconds));
   auto access_token = json_response[kJsonAccessTokenKey].get<std::string>();
   get_token_context.response->session_token =
       std::make_shared<std::string>(std::move(access_token));

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
@@ -62,7 +62,6 @@ constexpr char kDefaultGetTokenUrl[] =
 constexpr char kMetadataHeader[] = "Metadata";
 constexpr char kMetadataHeaderValue[] = "true";
 constexpr int kTokenTtlInSecondHeaderValue = 1000;
-constexpr int kExtendedTokenTtlInSecondHeaderValue = 1000;
 constexpr char kTokenPayloadValue[] = "b0Aaekm1IeizWZVKoBQQULOiiT_PDcQk";
 }  // namespace
 
@@ -92,14 +91,11 @@ TEST_F(AzureAuthTokenProviderTest,
                     Pair(kMetadataHeader, kMetadataHeaderValue))));
 
     http_context.response = std::make_shared<HttpResponse>();
-    const std::string kHttpResponseMock =
-        std::string(R"({
-        "access_token":")") +
-        kTokenPayloadValue + R"(",
-        "expires_in":)" +
-        std::to_string(kTokenTtlInSecondHeaderValue) + R"(,
-        "ext_expires_in": )" +
-        std::to_string(kExtendedTokenTtlInSecondHeaderValue) + R"(,
+    const std::string kHttpResponseMock = std::string(R"({
+        "access_token":")") + kTokenPayloadValue +
+                                          R"(",
+        "expires_in":)" + std::to_string(kTokenTtlInSecondHeaderValue) +
+                                          R"(,
         "token_type":"bearer"
       })";
     http_context.response->body = BytesBuffer(kHttpResponseMock);

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
@@ -58,8 +58,7 @@ using testing::UnorderedElementsAre;
 namespace {
 constexpr char kDefaultGetTokenUrl[] =
     "http://169.254.169.254/metadata/identity/oauth2/"
-    "token?api-version=2018-02-01&resource=https%3A%2F%2Fprivacysandboxkms."
-    "azure.net";
+    "token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com";
 constexpr char kMetadataHeader[] = "Metadata";
 constexpr char kMetadataHeaderValue[] = "true";
 constexpr int kTokenTtlInSecondHeaderValue = 1000;

--- a/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
+++ b/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider_test.cc
@@ -57,8 +57,9 @@ using testing::UnorderedElementsAre;
 
 namespace {
 constexpr char kDefaultGetTokenUrl[] =
-    "http://169.254.169.254/metadata/identity/oauth2/"
-    "token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com";
+    "http://169.254.169.254/metadata/identity/oauth2/token";
+constexpr char kGetTokenQuery[] =
+    "?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F";
 constexpr char kMetadataHeader[] = "Metadata";
 constexpr char kMetadataHeaderValue[] = "true";
 constexpr int kTokenTtlInSecondHeaderValue = 1000;
@@ -85,7 +86,9 @@ TEST_F(AzureAuthTokenProviderTest,
   EXPECT_CALL(http_client_, PerformRequest).WillOnce([](auto& http_context) {
     http_context.result = SuccessExecutionResult();
     EXPECT_EQ(http_context.request->method, HttpMethod::GET);
-    EXPECT_THAT(http_context.request->path, Pointee(Eq(kDefaultGetTokenUrl)));
+    EXPECT_THAT(http_context.request->path,
+                Pointee(Eq(std::string(kDefaultGetTokenUrl) +
+                           std::string(kGetTokenQuery))));
     EXPECT_THAT(http_context.request->headers,
                 Pointee(UnorderedElementsAre(
                     Pair(kMetadataHeader, kMetadataHeaderValue))));
@@ -94,8 +97,8 @@ TEST_F(AzureAuthTokenProviderTest,
     const std::string kHttpResponseMock = std::string(R"({
         "access_token":")") + kTokenPayloadValue +
                                           R"(",
-        "expires_in":)" + std::to_string(kTokenTtlInSecondHeaderValue) +
-                                          R"(,
+        "expires_in":")" + std::to_string(kTokenTtlInSecondHeaderValue) +
+                                          R"(",
         "token_type":"bearer"
       })";
     http_context.response->body = BytesBuffer(kHttpResponseMock);


### PR DESCRIPTION
see https://github.com/microsoft/privacy-sandbox-dev/pull/167


- Separate token url and query so that url can be reused for tokens for key vault (see https://github.com/KenGordon/bidding-auction-servers/pull/20)
- Remove ext_expires_in from validation because managed identity doesn't provide it
- Accept string not only integer for expires_in because managed identity's token returns it as string despite of https://www.rfc-editor.org/rfc/rfc6749
