### PR TITLE
Fix asan error

### DIFF
--- a/src/azure/attestation/src/evidence.cc
+++ b/src/azure/attestation/src/evidence.cc
@@ -39,7 +39,7 @@ std::string base64EncodeBytes(const uint8_t* decoded, size_t size) {
 }
 
 std::string getSnpEvidence(const std::string report_data) {
-  SnpReport* report;
+  std::unique_ptr<SnpReport> report;
 
   switch (getSnpType()) {
     case SnpType::SEV:
@@ -54,7 +54,7 @@ std::string getSnpEvidence(const std::string report_data) {
       CHECK(false) << "Unsupported or no SNP type";
   }
 
-  return base64EncodeBytes(reinterpret_cast<uint8_t*>(report),
+  return base64EncodeBytes(reinterpret_cast<uint8_t*>(report.get()),
                            sizeof(SnpReport));
 }
 

--- a/src/azure/attestation/src/sev.h
+++ b/src/azure/attestation/src/sev.h
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <charconv>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -58,7 +59,7 @@ struct Request {
   uint32_t error; /* firmware error code on failure (see psp-sev.h) */
 };
 
-SnpReport* getReport(const std::string report_data) {
+std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
   auto decodedBytes = absl::HexStringToBytes(report_data);
   size_t numBytesToCopy =
@@ -82,7 +83,7 @@ SnpReport* getReport(const std::string report_data) {
   auto rc = ioctl(sev_file, SEV_SNP_GUEST_MSG_REPORT, &payload);
   CHECK(rc >= 0) << "Failed to issue ioctl SEV_SNP_GUEST_MSG_REPORT";
 
-  SnpReport* report = new SnpReport;
+  auto report = std::make_unique<SnpReport>();
   *report = response.report;
   return report;
 }

--- a/src/azure/attestation/src/sev_guest.h
+++ b/src/azure/attestation/src/sev_guest.h
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 
 #include <algorithm>
+#include <memory>
 #include <string>
 
 #include "absl/log/check.h"
@@ -52,7 +53,7 @@ struct Request {
   uint64_t fw_err;  // firmware error code on failure (see psp-sev.h)
 };
 
-SnpReport* getReport(const std::string report_data) {
+std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
   auto decodedBytes = absl::HexStringToBytes(report_data);
   size_t numBytesToCopy =
@@ -73,7 +74,7 @@ SnpReport* getReport(const std::string report_data) {
   auto rc = ioctl(sev_guest_file, SNP_GET_REPORT, &payload);
   CHECK(rc >= 0) << "Failed to issue ioctl SNP_GET_REPORT";
 
-  SnpReport* report = new SnpReport;
+  auto report = std::make_unique<SnpReport>();
   *report = response.report;
   return report;
 }


### PR DESCRIPTION
Fixing the following error with asan enabled.

```
=================================================================
==19365==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1184 byte(s) in 1 object(s) allocated from:
    #0 0x564adb7ab32e in malloc (/workspace/privacy-sandbox-dev/repos/encrypt_payload+0xe7732e) (BuildId: abef375d2eeedec4)
    #1 0x7f477e2c3b28 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xaab28) (BuildId: fcd5414020056f1d95855868e00f3a7d479630fd)
    #2 0x564adb90a59d in google::scp::azure::attestation::getSnpEvidence(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /proc/self/cwd/src/azure/attestation/src/evidence.cc:47:16
    #3 0x564adb90858e in google::scp::azure::attestation::fetchSnpAttestation(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /proc/self/cwd/src/azure/attestation/src/report.cc:29:9
    #4 0x564adb89f8b6 in google::scp::cpio::client_providers::AzureKmsClientProvider::GetSessionCredentialsCallbackToDecrypt(google::scp::core::AsyncContext<google::cmrt::sdk::kms_service::v1::DecryptRequest, google::cmrt::sdk::kms_service::v1::DecryptResponse>&, google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&) /proc/self/cwd/src/cpio/client_providers/kms_client_provider/azure/azure_kms_client_provider.cc:254:34
    #5 0x564adb8afc0a in std::function<void (google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&)>::operator()(google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&) const /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #6 0x564adb8afc0a in google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>::Finish() /proc/self/cwd/./src/core/interface/async_context.h:143:7
    #7 0x564adcad09bf in google::scp::cpio::client_providers::AzureAuthTokenProvider::OnGetSessionTokenCallback(google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&, google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&) /proc/self/cwd/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc:211:21
    #8 0x564adb8b158a in std::function<void (google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&)>::operator()(google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&) const /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #9 0x564adb8b158a in google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>::Finish() /proc/self/cwd/./src/core/interface/async_context.h:143:7
    #10 0x564adc8c8144 in absl::internal_any_invocable::Impl<void ()>::operator()() /proc/self/cwd/external/com_google_absl/absl/functional/internal/any_invocable.h:868:1
    #11 0x564adc8c8144 in google::scp::core::AsyncTask::Execute() /proc/self/cwd/src/core/async_executor/async_task.h:61:5
    #12 0x564adc8c8144 in google::scp::core::SingleThreadAsyncExecutor::StartWorker() /proc/self/cwd/src/core/async_executor/single_thread_async_executor.cc:90:11
    #13 0x564adc8c8c79 in google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12::operator()(google::scp::core::SingleThreadAsyncExecutor*) const /proc/self/cwd/src/core/async_executor/single_thread_async_executor.cc:54:14
    #14 0x564adc8c8c79 in void std::__invoke_impl<void, google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>(std::__invoke_other, google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12&&, google::scp::core::SingleThreadAsyncExecutor*&&) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:60:14
    #15 0x564adc8c8c79 in std::__invoke_result<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>::type std::__invoke<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>(google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12&&, google::scp::core::SingleThreadAsyncExecutor*&&) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:95:14
    #16 0x564adc8c8c79 in void std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:244:13
    #17 0x564adc8c8c79 in std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:251:11
    #18 0x564adc8c8c79 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:195:13
    #19 0x7f477e2efdf3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6df3) (BuildId: fcd5414020056f1d95855868e00f3a7d479630fd)

Direct leak of 1184 byte(s) in 1 object(s) allocated from:
    #0 0x564adb7ab32e in malloc (/workspace/privacy-sandbox-dev/repos/encrypt_payload+0xe7732e) (BuildId: abef375d2eeedec4)
    #1 0x7f477e2c3b28 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xaab28) (BuildId: fcd5414020056f1d95855868e00f3a7d479630fd)
    #2 0x564adb90a59d in google::scp::azure::attestation::getSnpEvidence(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /proc/self/cwd/src/azure/attestation/src/evidence.cc:47:16
    #3 0x564adb90858e in google::scp::azure::attestation::fetchSnpAttestation(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /proc/self/cwd/src/azure/attestation/src/report.cc:29:9
    #4 0x564adb8fd9b1 in google::scp::cpio::client_providers::AzurePrivateKeyFetchingClientUtils::CreateHttpRequest(google::scp::cpio::client_providers::PrivateKeyFetchingRequest const&, google::scp::core::HttpRequest&) /proc/self/cwd/src/cpio/client_providers/private_key_fetcher_provider/azure/azure_private_key_fetcher_provider_utils.cc:43:18
    #5 0x564adb8e8da0 in google::scp::cpio::client_providers::AzurePrivateKeyFetcherProvider::OnGetSessionTokenCallback(google::scp::core::AsyncContext<google::scp::cpio::client_providers::PrivateKeyFetchingRequest, google::scp::core::HttpRequest>&, google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&) /proc/self/cwd/src/cpio/client_providers/private_key_fetcher_provider/azure/azure_private_key_fetcher_provider.cc:110:3
    #6 0x564adb8afc0a in std::function<void (google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&)>::operator()(google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&) const /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #7 0x564adb8afc0a in google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>::Finish() /proc/self/cwd/./src/core/interface/async_context.h:143:7
    #8 0x564adcad09bf in google::scp::cpio::client_providers::AzureAuthTokenProvider::OnGetSessionTokenCallback(google::scp::core::AsyncContext<google::scp::cpio::client_providers::GetSessionTokenRequest, google::scp::cpio::client_providers::GetSessionTokenResponse>&, google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&) /proc/self/cwd/src/cpio/client_providers/auth_token_provider/azure/azure_auth_token_provider.cc:211:21
    #9 0x564adb8b158a in std::function<void (google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&)>::operator()(google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>&) const /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/std_function.h:688:14
    #10 0x564adb8b158a in google::scp::core::AsyncContext<google::scp::core::HttpRequest, google::scp::core::HttpResponse>::Finish() /proc/self/cwd/./src/core/interface/async_context.h:143:7
    #11 0x564adc8c8144 in absl::internal_any_invocable::Impl<void ()>::operator()() /proc/self/cwd/external/com_google_absl/absl/functional/internal/any_invocable.h:868:1
    #12 0x564adc8c8144 in google::scp::core::AsyncTask::Execute() /proc/self/cwd/src/core/async_executor/async_task.h:61:5
    #13 0x564adc8c8144 in google::scp::core::SingleThreadAsyncExecutor::StartWorker() /proc/self/cwd/src/core/async_executor/single_thread_async_executor.cc:90:11
    #14 0x564adc8c8c79 in google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12::operator()(google::scp::core::SingleThreadAsyncExecutor*) const /proc/self/cwd/src/core/async_executor/single_thread_async_executor.cc:54:14
    #15 0x564adc8c8c79 in void std::__invoke_impl<void, google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>(std::__invoke_other, google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12&&, google::scp::core::SingleThreadAsyncExecutor*&&) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:60:14
    #16 0x564adc8c8c79 in std::__invoke_result<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>::type std::__invoke<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>(google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12&&, google::scp::core::SingleThreadAsyncExecutor*&&) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/invoke.h:95:14
    #17 0x564adc8c8c79 in void std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:244:13
    #18 0x564adc8c8c79 in std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:251:11
    #19 0x564adc8c8c79 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<google::scp::core::SingleThreadAsyncExecutor::SingleThreadAsyncExecutor(unsigned long, std::optional<unsigned long>)::$_12, google::scp::core::SingleThreadAsyncExecutor*>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/thread:195:13
    #20 0x7f477e2efdf3  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xd6df3) (BuildId: fcd5414020056f1d95855868e00f3a7d479630fd)

SUMMARY: AddressSanitizer: 2368 byte(s) leaked in 2 allocation(s).
make: *** [Makefile:112: standalone-encryption-test] Error 1
```

## Reproduction

Access to https://github.com/microsoft/privacy-sandbox-dev is required.

1. Create a KMS instance in ACI in a way you can shell into it. Then shell into it. Clone privacy-sandbox-dev.

2. Add the following to .bazelrc

```
--subcommands
--config=asan
--nobuild_tests_only
```

`--nobuild_tests_only` is to unset `--build_tests_only` set by `--config=asan`.

3. Run standalone test toolings
 ```
make standalone-test
```

## CI

https://github.com/microsoft/privacy-sandbox-dev/actions/runs/10165448934