### PR TITLE
Fix URL for quiche-envoy-integration

### DIFF
--- a/third_party/deps2.bzl
+++ b/third_party/deps2.bzl
@@ -97,8 +97,8 @@ def _quiche_deps():
     maybe(
         http_archive,
         name = "com_google_googleurl",
-        sha256 = "a1bc96169d34dcc1406ffb750deef3bc8718bd1f9069a2878838e1bd905de989",
-        urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl_9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7.tar.gz"],
+        sha256 = "3db90606ea9ca123d11f85c6fa3627a1e1e403d38c7fd1854a628cf1da3be5e2",
+        urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl-9cdb1f4d1a365ebdbcbf179dadf7f8aa5ee802e7.tar.gz"],
     )
 
 def _nodejs_deps():


### PR DESCRIPTION
Fix broken download.
Same change as https://github.com/privacysandbox/data-plane-shared-libraries/commit/158593616a63df924af1cb689f3915b8d32e9db1

CI: https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11365317440