### PR TITLE
Fix getting attestaion report for 6.1 kernel

### DIFF
--- a/src/azure/attestation/src/BUILD.bazel
+++ b/src/azure/attestation/src/BUILD.bazel
@@ -24,13 +24,15 @@ cc_library(
         "evidence.cc",
         "fake_report.cc",
         "report.cc",
+        "sev5.cc",
+        "sev6.cc",
         "snp.cc",
         "uvm_endorsements.cc",
     ],
     hdrs = [
         "attestation.h",
-        "sev.h",
-        "sev_guest.h",
+        "sev5.h",
+        "sev6.h",
     ],
     deps = [
         "//src/azure/attestation:utils",

--- a/src/azure/attestation/src/endorsements.cc
+++ b/src/azure/attestation/src/endorsements.cc
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef ATTESTATION_ENDORSEMENTS_H
-#define ATTESTATION_ENDORSEMENTS_H
-
 #include <string>
 
 #include "src/core/utils/base64.h"
@@ -59,5 +56,3 @@ std::string getSnpEndorsements() {
 }
 
 }  // namespace google::scp::azure::attestation
-
-#endif  // ATTESTATION_ENDORSEMENTS_H

--- a/src/azure/attestation/src/evidence.cc
+++ b/src/azure/attestation/src/evidence.cc
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef ATTESTATION_EVIDENCE_H
-#define ATTESTATION_EVIDENCE_H
-
 #include <fcntl.h>
 
 #include <openssl/base64.h>
@@ -25,8 +22,8 @@
 #include "src/core/utils/base64.h"
 
 #include "attestation.h"
-#include "sev.h"
-#include "sev_guest.h"
+#include "sev5.h"
+#include "sev6.h"
 
 namespace google::scp::azure::attestation {
 
@@ -59,5 +56,3 @@ std::string getSnpEvidence(const std::string report_data) {
 }
 
 }  // namespace google::scp::azure::attestation
-
-#endif  // ATTESTATION_EVIDENCE_H

--- a/src/azure/attestation/src/evidence.cc
+++ b/src/azure/attestation/src/evidence.cc
@@ -44,11 +44,11 @@ std::string getSnpEvidence(const std::string report_data) {
   switch (getSnpType()) {
     case SnpType::SEV:
       std::cout << "Getting report from /dev/sev" << std::endl;
-      report = sev::getReport(report_data);
+      report = sev5::getReport(report_data);
       break;
     case SnpType::SEV_GUEST:
       std::cout << "Getting report from /dev/sev-guest" << std::endl;
-      report = sev_guest::getReport(report_data);
+      report = sev6::getReport(report_data);
       break;
     default:
       CHECK(false) << "Unsupported or no SNP type";

--- a/src/azure/attestation/src/sev.h
+++ b/src/azure/attestation/src/sev.h
@@ -32,19 +32,9 @@
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 
-namespace google::scp::azure::attestation::sev {
+namespace google::scp::azure::attestation::sev5 {
 
-#define SEV_GUEST_IOC_TYPE 'S'
-#define SEV_SNP_GUEST_MSG_REQUEST \
-  _IOWR(SEV_GUEST_IOC_TYPE, 0x0,  \
-        struct google::scp::azure::attestation::sev::Request)
-#define SEV_SNP_GUEST_MSG_REPORT \
-  _IOWR(SEV_GUEST_IOC_TYPE, 0x1, \
-        struct google::scp::azure::attestation::sev::Request)
-#define SEV_SNP_GUEST_MSG_KEY    \
-  _IOWR(SEV_GUEST_IOC_TYPE, 0x2, \
-        struct google::scp::azure::attestation::sev::Request)
-
+namespace {
 /* linux kernel 5.15.* versions of the ioctls that talk to the PSP */
 
 /* From sev-snp driver include/uapi/linux/psp-sev-guest.h */
@@ -58,6 +48,12 @@ struct Request {
   uint64_t response_uaddr;
   uint32_t error; /* firmware error code on failure (see psp-sev.h) */
 };
+
+#define SEV_GUEST_IOC_TYPE 'S'
+#define SEV_SNP_GUEST_MSG_REQUEST _IOWR(SEV_GUEST_IOC_TYPE, 0x0, struct Request)
+#define SEV_SNP_GUEST_MSG_REPORT _IOWR(SEV_GUEST_IOC_TYPE, 0x1, struct Request)
+#define SEV_SNP_GUEST_MSG_KEY _IOWR(SEV_GUEST_IOC_TYPE, 0x2, struct Request)
+}  // namespace
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
@@ -88,6 +84,6 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   return report;
 }
 
-}  // namespace google::scp::azure::attestation::sev
+}  // namespace google::scp::azure::attestation::sev5
 
 #endif  // AZURE_ATTESTATION_SEV_H

--- a/src/azure/attestation/src/sev5.cc
+++ b/src/azure/attestation/src/sev5.cc
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef AZURE_ATTESTATION_SEV_H
-#define AZURE_ATTESTATION_SEV_H
-
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
@@ -29,6 +26,7 @@
 #include <string_view>
 #include <vector>
 
+#include "sev5.h"
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 
@@ -86,4 +84,3 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
 
 }  // namespace google::scp::azure::attestation::sev5
 
-#endif  // AZURE_ATTESTATION_SEV_H

--- a/src/azure/attestation/src/sev5.h
+++ b/src/azure/attestation/src/sev5.h
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
+#ifndef AZURE_ATTESTATION_SEV5_H
+#define AZURE_ATTESTATION_SEV5_H
+
+#include "attestation.h"
+#include <memory>
 #include <string>
 
-#include "utils/host_amd_certs.h"
+namespace google::scp::azure::attestation::sev5 {
+std::unique_ptr<SnpReport> getReport(const std::string report_data);
 
-using google::scp::azure::attestation::utils::getHostAmdCerts;
+}  // namespace google::scp::azure::attestation::sev5
 
-namespace google::scp::azure::attestation {
-
-std::string getSnpEndorsedTcb() {
-  auto host_certs_json = getHostAmdCerts();
-
-  // Extract the endorsed TCB from the JSON
-  std::string endorsed_tcb_reversed_endian = host_certs_json["tcbm"];
-
-  // Reverse the endianess of the endorsed TCB
-  std::string endorsed_tcb = "";
-  for (int i = endorsed_tcb_reversed_endian.length() - 2; i >= 0; i -= 2) {
-    endorsed_tcb += endorsed_tcb_reversed_endian.substr(i, 2);
-  }
-
-  return endorsed_tcb;
-}
-
-}  // namespace google::scp::azure::attestation
+#endif  // AZURE_ATTESTATION_SEV5_H

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef AZURE_ATTESTATION_SEV_GUEST_H
-#define AZURE_ATTESTATION_SEV_GUEST_H
-
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
@@ -26,6 +23,7 @@
 #include <memory>
 #include <string>
 
+#include "sev6.h"
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 
@@ -76,5 +74,3 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
 }
 
 }  // namespace google::scp::azure::attestation::sev6
-
-#endif  // AZURE_ATTESTATION_SEV_GUEST_H

--- a/src/azure/attestation/src/sev6.h
+++ b/src/azure/attestation/src/sev6.h
@@ -14,27 +14,16 @@
  * limitations under the License.
  */
 
+#ifndef AZURE_ATTESTATION_SEV6_H
+#define AZURE_ATTESTATION_SEV6_H
+
+#include "attestation.h"
+#include <memory>
 #include <string>
 
-#include "utils/host_amd_certs.h"
+namespace google::scp::azure::attestation::sev6 {
+std::unique_ptr<SnpReport> getReport(const std::string report_data);
 
-using google::scp::azure::attestation::utils::getHostAmdCerts;
+}  // namespace google::scp::azure::attestation::sev6
 
-namespace google::scp::azure::attestation {
-
-std::string getSnpEndorsedTcb() {
-  auto host_certs_json = getHostAmdCerts();
-
-  // Extract the endorsed TCB from the JSON
-  std::string endorsed_tcb_reversed_endian = host_certs_json["tcbm"];
-
-  // Reverse the endianess of the endorsed TCB
-  std::string endorsed_tcb = "";
-  for (int i = endorsed_tcb_reversed_endian.length() - 2; i >= 0; i -= 2) {
-    endorsed_tcb += endorsed_tcb_reversed_endian.substr(i, 2);
-  }
-
-  return endorsed_tcb;
-}
-
-}  // namespace google::scp::azure::attestation
+#endif  // AZURE_ATTESTATION_SEV6_H

--- a/src/azure/attestation/src/sev_guest.h
+++ b/src/azure/attestation/src/sev_guest.h
@@ -29,19 +29,9 @@
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 
-namespace google::scp::azure::attestation::sev_guest {
+namespace google::scp::azure::attestation::sev6 {
 
-#define SNP_GUEST_REQ_IOC_TYPE 'S'
-#define SNP_GET_REPORT               \
-  _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x0, \
-        struct google::scp::azure::attestation::sev::Request)
-#define SNP_GET_DERIVED_KEY          \
-  _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x1, \
-        struct google::scp::azure::attestation::sev::Request)
-#define SNP_GET_EXT_REPORT           \
-  _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x2, \
-        struct google::scp::azure::attestation::sev::Request)
-
+namespace {
 /* linux kernel 6.* versions of the ioctls that talk to the PSP */
 
 // aka/replaced by this from include/uapi/linux/sev-guest.h
@@ -52,6 +42,12 @@ struct Request {
   uint64_t resp_data;
   uint64_t fw_err;  // firmware error code on failure (see psp-sev.h)
 };
+
+#define SNP_GUEST_REQ_IOC_TYPE 'S'
+#define SNP_GET_REPORT _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x0, struct Request)
+#define SNP_GET_DERIVED_KEY _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x1, struct Request)
+#define SNP_GET_EXT_REPORT _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x2, struct Request)
+}  // namespace
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
@@ -79,6 +75,6 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   return report;
 }
 
-}  // namespace google::scp::azure::attestation::sev_guest
+}  // namespace google::scp::azure::attestation::sev6
 
 #endif  // AZURE_ATTESTATION_SEV_GUEST_H

--- a/src/azure/attestation/src/snp.cc
+++ b/src/azure/attestation/src/snp.cc
@@ -24,7 +24,7 @@ SnpType getSnpType() {
     return SnpType::SEV;
   }
   std::ifstream sev_guest_file("/dev/sev-guest");
-  if (sev_file.good()) {
+  if (sev_guest_file.good()) {
     return SnpType::SEV_GUEST;
   }
   return SnpType::NONE;


### PR DESCRIPTION
~~https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11591913895~~

Edit: Changed the name of the PR. It fixes

- [x] Fix the filestream variable to use
- [x] Fix Request struct to use
- [x] Use anonymous namespace so that Request struct becomes private to the file.
- [x] Handle pre-commit  error `src/azure/attestation/src/sev.h:37:  Do not use unnamed namespaces in header files.  See https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces for more information.  [build/namespaces_headers] [4]
Done processing src/azure/attestation/src/sev.h
Total errors found: 1`
- [ ] Pass CI (it runs with 6.1 kernel): ~~https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11594711508~~ https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11595098115
- [ ] Test fetching report with 5.15 kernel environment
- [X] Statically link print_report for portability