### PR TITLE
Continue fixing 6.1 report

### DIFF
--- a/src/azure/attestation/src/BUILD.bazel
+++ b/src/azure/attestation/src/BUILD.bazel
@@ -47,6 +47,9 @@ cc_library(
 cc_binary(
     name = "print_report",
     srcs = ["print_report.cc"],
+    features = ["fully_static_link"],
+    linkopts = ["-static"],
+    linkstatic = True,
     deps = [
         "attestation",
     ],

--- a/src/azure/attestation/src/sev5.cc
+++ b/src/azure/attestation/src/sev5.cc
@@ -56,10 +56,10 @@ struct Request {
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
-  auto decodedBytes = absl::HexStringToBytes(report_data);
-  size_t numBytesToCopy =
-      std::min(decodedBytes.size(), sizeof(request.report_data));
-  std::copy(decodedBytes.begin(), decodedBytes.begin() + numBytesToCopy,
+  auto decoded_bytes = absl::HexStringToBytes(report_data);
+  size_t num_bytes_to_copy =
+      std::min(decoded_bytes.size(), sizeof(request.report_data));
+  std::copy(decoded_bytes.begin(), decoded_bytes.begin() + num_bytes_to_copy,
             request.report_data);
 
   SnpResponse response = {};

--- a/src/azure/attestation/src/sev5.cc
+++ b/src/azure/attestation/src/sev5.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "sev5.h"
+
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
@@ -26,7 +28,6 @@
 #include <string_view>
 #include <vector>
 
-#include "sev5.h"
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 
@@ -83,4 +84,3 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
 }
 
 }  // namespace google::scp::azure::attestation::sev5
-

--- a/src/azure/attestation/src/sev5.h
+++ b/src/azure/attestation/src/sev5.h
@@ -17,9 +17,10 @@
 #ifndef AZURE_ATTESTATION_SEV5_H
 #define AZURE_ATTESTATION_SEV5_H
 
-#include "attestation.h"
 #include <memory>
 #include <string>
+
+#include "attestation.h"
 
 namespace google::scp::azure::attestation::sev5 {
 std::unique_ptr<SnpReport> getReport(const std::string report_data);

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -42,10 +42,16 @@ struct Request {
   uint64_t fw_err;  // firmware error code on failure (see psp-sev.h)
 };
 
+struct RequestWrapper {
+  /* response data, see SEV-SNP spec for the format */
+  uint8_t data[4000];
+};
+
 #define SNP_GUEST_REQ_IOC_TYPE 'S'
 #define SNP_GET_REPORT _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x0, struct Request)
 #define SNP_GET_DERIVED_KEY _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x1, struct Request)
 #define SNP_GET_EXT_REPORT _IOWR(SNP_GUEST_REQ_IOC_TYPE, 0x2, struct Request)
+
 }  // namespace
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
@@ -56,12 +62,12 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   std::copy(decodedBytes.begin(), decodedBytes.begin() + numBytesToCopy,
             request.report_data);
 
-  SnpResponse response = {};
+  RequestWrapper resp_wrapper = {};
 
   Request payload = {
       .msg_version = 1,
       .req_data = (uint64_t)&request,
-      .resp_data = (uint64_t)&response,
+      .resp_data = (uint64_t)&resp_wrapper,
   };
 
   auto sev_guest_file = open("/dev/sev-guest", O_RDWR | O_CLOEXEC);
@@ -69,8 +75,10 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   auto rc = ioctl(sev_guest_file, SNP_GET_REPORT, &payload);
   CHECK(rc >= 0) << "Failed to issue ioctl SNP_GET_REPORT";
 
+  SnpResponse* response = (SnpResponse*)&resp_wrapper.data;
+
   auto report = std::make_unique<SnpReport>();
-  *report = response.report;
+  *report = response->report;
   return report;
 }
 

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -56,10 +56,10 @@ struct RequestWrapper {
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
-  auto decodedBytes = absl::HexStringToBytes(report_data);
-  size_t numBytesToCopy =
-      std::min(decodedBytes.size(), sizeof(request.report_data));
-  std::copy(decodedBytes.begin(), decodedBytes.begin() + numBytesToCopy,
+  auto decoded_bytes = absl::HexStringToBytes(report_data);
+  size_t num_bytes_to_copy =
+      std::min(decoded_bytes.size(), sizeof(request.report_data));
+  std::copy(decoded_bytes.begin(), decoded_bytes.begin() + num_bytes_to_copy,
             request.report_data);
 
   RequestWrapper resp_wrapper = {};

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "sev6.h"
+
 #include <fcntl.h>
 #include <stdint.h>
 #include <sys/ioctl.h>
@@ -23,7 +25,6 @@
 #include <memory>
 #include <string>
 
-#include "sev6.h"
 #include "absl/log/check.h"
 #include "absl/strings/escaping.h"
 

--- a/src/azure/attestation/src/sev6.h
+++ b/src/azure/attestation/src/sev6.h
@@ -17,9 +17,10 @@
 #ifndef AZURE_ATTESTATION_SEV6_H
 #define AZURE_ATTESTATION_SEV6_H
 
-#include "attestation.h"
 #include <memory>
 #include <string>
+
+#include "attestation.h"
 
 namespace google::scp::azure::attestation::sev6 {
 std::unique_ptr<SnpReport> getReport(const std::string report_data);


### PR DESCRIPTION
https://github.com/KenGordon/data-plane-shared-libraries/pull/47 was merged before it finishes. So I'll continue it here

- [x] Fix the filestream variable to use
- [x] Fix Request struct to use
- [x] Use anonymous namespace so that Request struct becomes private to the file.
- [x] Handle pre-commit  error `src/azure/attestation/src/sev.h:37:  Do not use unnamed namespaces in header files.  See https://google-styleguide.googlecode.com/svn/trunk/cppguide.xml#Namespaces for more information.  [build/namespaces_headers] [4]
Done processing src/azure/attestation/src/sev.h
Total errors found: 1`
- [x] Pass CI (it runs with 6.1 kernel): ~~https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11594711508~~ ~~https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11595098115~~ https://github.com/microsoft/privacy-sandbox-dev/actions/runs/11598046167
- [x] Test fetching report with 5.15 kernel environment
- [X] Statically link print_report for portability