### PR TITLE
Validate the report_data field in the attestation test

### DIFF
--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -55,7 +55,9 @@ struct RequestWrapper {
 }  // namespace
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
+  // Aggregate initialising SnpRequest ensures fields are zero'ed
   SnpRequest request = {};
+
   std::string decoded_bytes = absl::HexStringToBytes(report_data);
   size_t num_bytes_to_copy =
       std::min(decoded_bytes.size(), sizeof(request.report_data));

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -59,6 +59,9 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
 
   std::string decoded_bytes = absl::HexStringToBytes(report_data);
+
+  // Copy the number of bytes provided up to the size of report data to avoid
+  // copying out of bounds of the report data field
   size_t num_bytes_to_copy =
       std::min(decoded_bytes.size(), sizeof(request.report_data));
   std::copy(decoded_bytes.begin(), decoded_bytes.begin() + num_bytes_to_copy,

--- a/src/azure/attestation/src/sev6.cc
+++ b/src/azure/attestation/src/sev6.cc
@@ -56,7 +56,7 @@ struct RequestWrapper {
 
 std::unique_ptr<SnpReport> getReport(const std::string report_data) {
   SnpRequest request = {};
-  auto decoded_bytes = absl::HexStringToBytes(report_data);
+  std::string decoded_bytes = absl::HexStringToBytes(report_data);
   size_t num_bytes_to_copy =
       std::min(decoded_bytes.size(), sizeof(request.report_data));
   std::copy(decoded_bytes.begin(), decoded_bytes.begin() + num_bytes_to_copy,
@@ -70,14 +70,14 @@ std::unique_ptr<SnpReport> getReport(const std::string report_data) {
       .resp_data = (uint64_t)&resp_wrapper,
   };
 
-  auto sev_guest_file = open("/dev/sev-guest", O_RDWR | O_CLOEXEC);
+  int sev_guest_file = open("/dev/sev-guest", O_RDWR | O_CLOEXEC);
 
-  auto rc = ioctl(sev_guest_file, SNP_GET_REPORT, &payload);
+  int rc = ioctl(sev_guest_file, SNP_GET_REPORT, &payload);
   CHECK(rc >= 0) << "Failed to issue ioctl SNP_GET_REPORT";
 
   SnpResponse* response = (SnpResponse*)&resp_wrapper.data;
 
-  auto report = std::make_unique<SnpReport>();
+  std::unique_ptr<SnpReport> report = std::make_unique<SnpReport>();
   *report = response->report;
   return report;
 }

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "src/azure/attestation/src/sev6.h"
 #include "src/core/utils/base64.h"
 
 using google::scp::azure::attestation::AttestationReport;
@@ -24,6 +25,7 @@ using google::scp::azure::attestation::fetchFakeSnpAttestation;
 using google::scp::azure::attestation::fetchSnpAttestation;
 using google::scp::azure::attestation::hasSnp;
 using google::scp::azure::attestation::SnpReport;
+using google::scp::azure::attestation::sev6::getReport;
 
 using google::scp::core::utils::Base64Decode;
 
@@ -133,5 +135,65 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationNonSnp) {
     return;
   }
   EXPECT_FALSE(fetchSnpAttestation().has_value());
+}
+
+TEST_F(JsonAttestationReportTest, GetReport) {
+  if (!hasSnp()) {
+    return;
+  }
+  // Define test inputs and outputs
+  std::string report_data = "";
+  uint8_t expected[64] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  };
+
+  std::unique_ptr<SnpReport> snp_report = getReport(report_data);
+
+  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
+                         std::begin(snp_report.get()->report_data)));
+}
+
+TEST_F(JsonAttestationReportTest, GetReportWithReportDataUnder64) {
+  if (!hasSnp()) {
+    return;
+  }
+  // Define test inputs and outputs
+  std::string report_data = toHex("example_report_data");
+  uint8_t expected[64] = {
+      'e', 'x', 'a', 'm', 'p', 'l', 'e', '_', 'r', 'e', 'p', 'o', 'r',
+      't', '_', 'd', 'a', 't', 'a', 0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+  };
+
+  std::unique_ptr<SnpReport> snp_report = getReport(report_data);
+
+  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
+                         std::begin(snp_report.get()->report_data)));
+}
+
+TEST_F(JsonAttestationReportTest, GetReportWithReportDataOver64) {
+  if (!hasSnp()) {
+    return;
+  }
+  // Define test inputs and outputs
+  std::string report_data = toHex(
+      "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_"
+      "data_length");
+  uint8_t expected[64] = {
+      'a', '_', 'v', 'e', 'r', 'y', '_', 'l', 'o', 'n', 'g', '_', 'r',
+      'e', 'p', 'o', 'r', 't', '_', 'd', 'a', 't', 'a', '_', 's', 't',
+      'r', 'i', 'n', 'g', '_', 'w', 'h', 'i', 'c', 'h', '_', 'i', 's',
+      '_', 's', 'o', '_', 'l', 'o', 'n', 'g', '_', 't', 'h', 'a', 't',
+      '_', 'i', 't', '_', 'e', 'x', 'c', 'e', 'e', 'd', 's', '_',
+  };
+
+  std::unique_ptr<SnpReport> snp_report = getReport(report_data);
+
+  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
+                         std::begin(snp_report.get()->report_data)));
 }
 }  // namespace google::scp::cc::azure::attestation::test

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "src/azure/attestation/src/attestation.h"
+#include "src/core/utils/base64.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -20,8 +21,44 @@
 using google::scp::azure::attestation::fetchFakeSnpAttestation;
 using google::scp::azure::attestation::fetchSnpAttestation;
 using google::scp::azure::attestation::hasSnp;
+using google::scp::azure::attestation::SnpReport;
+
+using google::scp::core::utils::Base64Decode;
 
 namespace google::scp::cc::azure::attestation::test {
+
+std::string toHex(const std::string& input) {
+  std::stringstream hex_stream;
+  for (unsigned char c : input) {
+    hex_stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c);
+  }
+  return hex_stream.str();
+}
+
+std::string getReportData(const std::string& snp_evidence_b64) {
+    std::string snp_evidence_str;
+    Base64Decode(snp_evidence_b64, snp_evidence_str);
+
+    // Parse the byte string into the SnpReport struct
+    std::vector<uint8_t> snp_evidence_bytes(snp_evidence_str.begin(), snp_evidence_str.end());
+    SnpReport* snp_report = reinterpret_cast<SnpReport*>(snp_evidence_bytes.data());
+
+    // Parse the report data into a string since all tests provided as a string
+    std::string report_data_str(reinterpret_cast<const char*>(snp_report->report_data), sizeof(snp_report->report_data));
+
+    // Remove any trailing zeros as all report data is padded up to 64 bytes
+    // Crucially if there is junk memory by accident, this will be left in and
+    // tests will fail.
+    size_t end = report_data_str.find_last_not_of('\0');
+    if (end == std::string::npos) {
+        report_data_str.clear();
+    } else {
+        report_data_str.resize(end + 1);
+    }
+
+    std::cout << "report_data: \"" << report_data_str << "\"" << std::endl;
+    return report_data_str;
+}
 
 class JsonAttestationReportTest : public ::testing::Test {
  protected:
@@ -38,24 +75,29 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestation) {
   if (!hasSnp()) {
     return;
   }
-  EXPECT_TRUE(fetchSnpAttestation().has_value());
+  auto attestation_report = fetchSnpAttestation();
+  EXPECT_TRUE(attestation_report.has_value());
+  EXPECT_EQ(getReportData(attestation_report->evidence), "");
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
   if (!hasSnp()) {
     return;
   }
-  EXPECT_TRUE(fetchSnpAttestation("example_report_data").has_value());
+  std::string report_data = "example_report_data";
+  auto attestation_report = fetchSnpAttestation(toHex(report_data));
+  EXPECT_TRUE(attestation_report.has_value());
+  EXPECT_EQ(getReportData(attestation_report->evidence), report_data);
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   if (!hasSnp()) {
     return;
   }
-  EXPECT_TRUE(fetchSnpAttestation("a_very_long_report_data_string_which_is_so_"
-                                  "long_that_it_exceeds_report_"
-                                  "data_length")
-                  .has_value());
+  std::string report_data = "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_data_length";
+  auto attestation_report = fetchSnpAttestation(toHex(report_data));
+  EXPECT_TRUE(attestation_report.has_value());
+  EXPECT_EQ(getReportData(attestation_report->evidence), report_data.substr(0, 64));
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNonSnp) {

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -52,6 +52,9 @@ std::string getReportData(const std::string& snp_evidence_b64) {
       reinterpret_cast<const char*>(snp_report->report_data),
       sizeof(snp_report->report_data));
 
+  // Assert the size field in std::string constructor is respected
+  EXPECT_EQ(report_data_str.size(), sizeof(snp_report->report_data));
+
   // Remove any trailing zeros as all report data is padded up to 64 bytes
   // Crucially if there is junk memory by accident, this will be left in and
   // tests will fail.

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -107,6 +107,28 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
   EXPECT_EQ(getReportData(attestation_report->evidence), expected);
 }
 
+TEST_F(JsonAttestationReportTest, FetchRealAttestationReportDataWithNull) {
+  if (!hasSnp()) {
+    return;
+  }
+  // Define test inputs and outputs
+  std::string report_data =
+      "6578616d706c655f776974685f005f63686172";  // "example_with_\0_char"
+  std::array<uint8_t, 64> expected = {
+      'e', 'x', 'a', 'm', 'p', 'l', 'e', '_', 'w', 'i', 't', 'h', '_',
+      0,   '_', 'c', 'h', 'a', 'r', 0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+  };
+
+  std::optional<AttestationReport> attestation_report =
+      fetchSnpAttestation(report_data);
+
+  EXPECT_TRUE(attestation_report.has_value());
+  EXPECT_EQ(getReportData(attestation_report->evidence), expected);
+}
+
 TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   if (!hasSnp()) {
     return;

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -19,6 +19,7 @@
 
 #include "src/core/utils/base64.h"
 
+using google::scp::azure::attestation::AttestationReport;
 using google::scp::azure::attestation::fetchFakeSnpAttestation;
 using google::scp::azure::attestation::fetchSnpAttestation;
 using google::scp::azure::attestation::hasSnp;
@@ -75,7 +76,7 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestation) {
   if (!hasSnp()) {
     return;
   }
-  auto attestation_report = fetchSnpAttestation();
+  std::optional<AttestationReport> attestation_report = fetchSnpAttestation();
   EXPECT_TRUE(attestation_report.has_value());
   EXPECT_EQ(
     getReportData(attestation_report->evidence),
@@ -86,8 +87,8 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
   if (!hasSnp()) {
     return;
   }
-  std::string report_data = "example_report_data";
-  auto attestation_report = fetchSnpAttestation(toHex(report_data));
+  std::optional<AttestationReport> attestation_report =
+      fetchSnpAttestation(report_data);
   EXPECT_TRUE(attestation_report.has_value());
   EXPECT_EQ(
     getReportData(attestation_report->evidence),
@@ -101,8 +102,8 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   }
   std::string report_data =
       "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_"
-      "data_length";
-  auto attestation_report = fetchSnpAttestation(toHex(report_data));
+  std::optional<AttestationReport> attestation_report =
+      fetchSnpAttestation(report_data);
   EXPECT_TRUE(attestation_report.has_value());
   EXPECT_EQ(
     getReportData(attestation_report->evidence),

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 #include "src/azure/attestation/src/attestation.h"
-#include "src/core/utils/base64.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
+#include "src/core/utils/base64.h"
 
 using google::scp::azure::attestation::fetchFakeSnpAttestation;
 using google::scp::azure::attestation::fetchSnpAttestation;
@@ -30,34 +31,39 @@ namespace google::scp::cc::azure::attestation::test {
 std::string toHex(const std::string& input) {
   std::stringstream hex_stream;
   for (unsigned char c : input) {
-    hex_stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c);
+    hex_stream << std::hex << std::setw(2) << std::setfill('0')
+               << static_cast<int>(c);
   }
   return hex_stream.str();
 }
 
 std::string getReportData(const std::string& snp_evidence_b64) {
-    std::string snp_evidence_str;
-    Base64Decode(snp_evidence_b64, snp_evidence_str);
+  std::string snp_evidence_str;
+  Base64Decode(snp_evidence_b64, snp_evidence_str);
 
-    // Parse the byte string into the SnpReport struct
-    std::vector<uint8_t> snp_evidence_bytes(snp_evidence_str.begin(), snp_evidence_str.end());
-    SnpReport* snp_report = reinterpret_cast<SnpReport*>(snp_evidence_bytes.data());
+  // Parse the byte string into the SnpReport struct
+  std::vector<uint8_t> snp_evidence_bytes(snp_evidence_str.begin(),
+                                          snp_evidence_str.end());
+  SnpReport* snp_report =
+      reinterpret_cast<SnpReport*>(snp_evidence_bytes.data());
 
-    // Parse the report data into a string since all tests provided as a string
-    std::string report_data_str(reinterpret_cast<const char*>(snp_report->report_data), sizeof(snp_report->report_data));
+  // Parse the report data into a string since all tests provided as a string
+  std::string report_data_str(
+      reinterpret_cast<const char*>(snp_report->report_data),
+      sizeof(snp_report->report_data));
 
-    // Remove any trailing zeros as all report data is padded up to 64 bytes
-    // Crucially if there is junk memory by accident, this will be left in and
-    // tests will fail.
-    size_t end = report_data_str.find_last_not_of('\0');
-    if (end == std::string::npos) {
-        report_data_str.clear();
-    } else {
-        report_data_str.resize(end + 1);
-    }
+  // Remove any trailing zeros as all report data is padded up to 64 bytes
+  // Crucially if there is junk memory by accident, this will be left in and
+  // tests will fail.
+  size_t end = report_data_str.find_last_not_of('\0');
+  if (end == std::string::npos) {
+    report_data_str.clear();
+  } else {
+    report_data_str.resize(end + 1);
+  }
 
-    std::cout << "report_data: \"" << report_data_str << "\"" << std::endl;
-    return report_data_str;
+  std::cout << "report_data: \"" << report_data_str << "\"" << std::endl;
+  return report_data_str;
 }
 
 class JsonAttestationReportTest : public ::testing::Test {
@@ -94,10 +100,13 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   if (!hasSnp()) {
     return;
   }
-  std::string report_data = "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_data_length";
+  std::string report_data =
+      "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_"
+      "data_length";
   auto attestation_report = fetchSnpAttestation(toHex(report_data));
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(getReportData(attestation_report->evidence), report_data.substr(0, 64));
+  EXPECT_EQ(getReportData(attestation_report->evidence),
+            report_data.substr(0, 64));
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNonSnp) {

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -40,6 +40,13 @@ std::string toHex(const std::string& input) {
   return hex_stream.str();
 }
 
+// Narrowed equivalent of C++ 20's std::to_array
+std::array<uint8_t, 64> to_array(uint8_t (&c_array)[64]) {
+  std::array<uint8_t, 64> arr;
+  std::copy(std::begin(c_array), std::end(c_array), arr.begin());
+  return arr;
+}
+
 std::array<uint8_t, 64> getReportData(const std::string& snp_evidence_b64) {
   std::string snp_evidence_str;
   Base64Decode(snp_evidence_b64, snp_evidence_str);
@@ -51,10 +58,7 @@ std::array<uint8_t, 64> getReportData(const std::string& snp_evidence_b64) {
   EXPECT_EQ(snp_evidence_bytes.size(), sizeof(SnpReport));
   std::memcpy(&snp_report, snp_evidence_bytes.data(), sizeof(SnpReport));
 
-  std::array<uint8_t, 64> report_data;
-  EXPECT_EQ(sizeof(snp_report.report_data), report_data.size());
-  std::memcpy(&report_data, snp_report.report_data, report_data.size());
-  return report_data;
+  return to_array(snp_report.report_data);
 }
 
 class JsonAttestationReportTest : public ::testing::Test {
@@ -165,7 +169,7 @@ TEST_F(JsonAttestationReportTest, GetReport) {
   }
   // Define test inputs and outputs
   std::string report_data = "";
-  uint8_t expected[64] = {
+  std::array<uint8_t, 64> expected = {
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -173,8 +177,7 @@ TEST_F(JsonAttestationReportTest, GetReport) {
 
   std::unique_ptr<SnpReport> snp_report = getReport(report_data);
 
-  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
-                         std::begin(snp_report.get()->report_data)));
+  EXPECT_EQ(to_array(snp_report->report_data), expected);
 }
 
 TEST_F(JsonAttestationReportTest, GetReportWithReportDataUnder64) {
@@ -183,7 +186,7 @@ TEST_F(JsonAttestationReportTest, GetReportWithReportDataUnder64) {
   }
   // Define test inputs and outputs
   std::string report_data = toHex("example_report_data");
-  uint8_t expected[64] = {
+  std::array<uint8_t, 64> expected = {
       'e', 'x', 'a', 'm', 'p', 'l', 'e', '_', 'r', 'e', 'p', 'o', 'r',
       't', '_', 'd', 'a', 't', 'a', 0,   0,   0,   0,   0,   0,   0,
       0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
@@ -193,8 +196,7 @@ TEST_F(JsonAttestationReportTest, GetReportWithReportDataUnder64) {
 
   std::unique_ptr<SnpReport> snp_report = getReport(report_data);
 
-  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
-                         std::begin(snp_report.get()->report_data)));
+  EXPECT_EQ(to_array(snp_report->report_data), expected);
 }
 
 TEST_F(JsonAttestationReportTest, GetReportWithReportDataOver64) {
@@ -205,7 +207,7 @@ TEST_F(JsonAttestationReportTest, GetReportWithReportDataOver64) {
   std::string report_data = toHex(
       "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_"
       "data_length");
-  uint8_t expected[64] = {
+  std::array<uint8_t, 64> expected = {
       'a', '_', 'v', 'e', 'r', 'y', '_', 'l', 'o', 'n', 'g', '_', 'r',
       'e', 'p', 'o', 'r', 't', '_', 'd', 'a', 't', 'a', '_', 's', 't',
       'r', 'i', 'n', 'g', '_', 'w', 'h', 'i', 'c', 'h', '_', 'i', 's',
@@ -215,7 +217,6 @@ TEST_F(JsonAttestationReportTest, GetReportWithReportDataOver64) {
 
   std::unique_ptr<SnpReport> snp_report = getReport(report_data);
 
-  EXPECT_TRUE(std::equal(std::begin(expected), std::end(expected),
-                         std::begin(snp_report.get()->report_data)));
+  EXPECT_EQ(to_array(snp_report->report_data), expected);
 }
 }  // namespace google::scp::cc::azure::attestation::test

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -133,6 +133,29 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationReportDataWithNull) {
   EXPECT_EQ(getReportData(attestation_report->evidence), expected);
 }
 
+TEST_F(JsonAttestationReportTest, FetchRealAttestationReportDataWithNonChar) {
+  if (!hasSnp()) {
+    return;
+  }
+  // Define test inputs and outputs
+  std::string report_data =
+      "6578616d706c655f776974685fff5f63686172";  // "example_with_?_char" where
+                                                 // ? is 255
+  std::array<uint8_t, 64> expected = {
+      'e', 'x', 'a', 'm', 'p', 'l', 'e', '_', 'w', 'i', 't', 'h', '_',
+      255, '_', 'c', 'h', 'a', 'r', 0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+  };
+
+  std::optional<AttestationReport> attestation_report =
+      fetchSnpAttestation(report_data);
+
+  EXPECT_TRUE(attestation_report.has_value());
+  EXPECT_EQ(getReportData(attestation_report->evidence), expected);
+}
+
 TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   if (!hasSnp()) {
     return;

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -44,28 +44,19 @@ std::string getReportData(const std::string& snp_evidence_b64) {
   // Parse the byte string into the SnpReport struct
   std::vector<uint8_t> snp_evidence_bytes(snp_evidence_str.begin(),
                                           snp_evidence_str.end());
-  SnpReport* snp_report =
-      reinterpret_cast<SnpReport*>(snp_evidence_bytes.data());
+  SnpReport snp_report;
+  EXPECT_EQ(snp_evidence_bytes.size(), sizeof(SnpReport));
+  std::memcpy(&snp_report, snp_evidence_bytes.data(), sizeof(SnpReport));
 
   // Parse the report data into a string since all tests provided as a string
   std::string report_data_str(
-      reinterpret_cast<const char*>(snp_report->report_data),
-      sizeof(snp_report->report_data));
+      reinterpret_cast<const char*>(snp_report.report_data),
+      sizeof(snp_report.report_data));
 
   // Assert the size field in std::string constructor is respected
-  EXPECT_EQ(report_data_str.size(), sizeof(snp_report->report_data));
+  EXPECT_EQ(report_data_str.size(), sizeof(snp_report.report_data));
 
-  // Remove any trailing zeros as all report data is padded up to 64 bytes
-  // Crucially if there is junk memory by accident, this will be left in and
-  // tests will fail.
-  size_t end = report_data_str.find_last_not_of('\0');
-  if (end == std::string::npos) {
-    report_data_str.clear();
-  } else {
-    report_data_str.resize(end + 1);
-  }
-
-  std::cout << "report_data: \"" << report_data_str << "\"" << std::endl;
+  std::cout << "report_data (without padding): \"" << report_data_str << "\"" << std::endl;
   return report_data_str;
 }
 
@@ -86,7 +77,9 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestation) {
   }
   auto attestation_report = fetchSnpAttestation();
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(getReportData(attestation_report->evidence), "");
+  EXPECT_EQ(
+    getReportData(attestation_report->evidence),
+    std::string(64, '\0'));
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
@@ -96,7 +89,10 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
   std::string report_data = "example_report_data";
   auto attestation_report = fetchSnpAttestation(toHex(report_data));
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(getReportData(attestation_report->evidence), report_data);
+  EXPECT_EQ(
+    getReportData(attestation_report->evidence),
+    report_data.append(64 - report_data.size(), '\0')
+  );
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
@@ -108,8 +104,10 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
       "data_length";
   auto attestation_report = fetchSnpAttestation(toHex(report_data));
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(getReportData(attestation_report->evidence),
-            report_data.substr(0, 64));
+  EXPECT_EQ(
+    getReportData(attestation_report->evidence),
+    report_data.substr(0, 64)
+  );
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNonSnp) {

--- a/src/azure/attestation/test/attestation_test.cc
+++ b/src/azure/attestation/test/attestation_test.cc
@@ -38,7 +38,7 @@ std::string toHex(const std::string& input) {
   return hex_stream.str();
 }
 
-std::string getReportData(const std::string& snp_evidence_b64) {
+std::array<uint8_t, 64> getReportData(const std::string& snp_evidence_b64) {
   std::string snp_evidence_str;
   Base64Decode(snp_evidence_b64, snp_evidence_str);
 
@@ -49,16 +49,10 @@ std::string getReportData(const std::string& snp_evidence_b64) {
   EXPECT_EQ(snp_evidence_bytes.size(), sizeof(SnpReport));
   std::memcpy(&snp_report, snp_evidence_bytes.data(), sizeof(SnpReport));
 
-  // Parse the report data into a string since all tests provided as a string
-  std::string report_data_str(
-      reinterpret_cast<const char*>(snp_report.report_data),
-      sizeof(snp_report.report_data));
-
-  // Assert the size field in std::string constructor is respected
-  EXPECT_EQ(report_data_str.size(), sizeof(snp_report.report_data));
-
-  std::cout << "report_data (without padding): \"" << report_data_str << "\"" << std::endl;
-  return report_data_str;
+  std::array<uint8_t, 64> report_data;
+  EXPECT_EQ(sizeof(snp_report.report_data), report_data.size());
+  std::memcpy(&report_data, snp_report.report_data, report_data.size());
+  return report_data;
 }
 
 class JsonAttestationReportTest : public ::testing::Test {
@@ -76,39 +70,62 @@ TEST_F(JsonAttestationReportTest, FetchRealAttestation) {
   if (!hasSnp()) {
     return;
   }
+  // Define test inputs and outputs
+  // Input is omitted as we're testing default is ""
+  std::array<uint8_t, 64> expected = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  };
+
   std::optional<AttestationReport> attestation_report = fetchSnpAttestation();
+
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(
-    getReportData(attestation_report->evidence),
-    std::string(64, '\0'));
+  EXPECT_EQ(getReportData(attestation_report->evidence), expected);
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNormalReportData) {
   if (!hasSnp()) {
     return;
   }
+  // Define test inputs and outputs
+  std::string report_data = toHex("example_report_data");
+  std::array<uint8_t, 64> expected = {
+      'e', 'x', 'a', 'm', 'p', 'l', 'e', '_', 'r', 'e', 'p', 'o', 'r',
+      't', '_', 'd', 'a', 't', 'a', 0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+      0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
+  };
+
   std::optional<AttestationReport> attestation_report =
       fetchSnpAttestation(report_data);
+
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(
-    getReportData(attestation_report->evidence),
-    report_data.append(64 - report_data.size(), '\0')
-  );
+  EXPECT_EQ(getReportData(attestation_report->evidence), expected);
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationLongReportData) {
   if (!hasSnp()) {
     return;
   }
-  std::string report_data =
+  // Define test inputs and outputs
+  std::string report_data = toHex(
       "a_very_long_report_data_string_which_is_so_long_that_it_exceeds_report_"
+      "data_length");
+  std::array<uint8_t, 64> expected = {
+      'a', '_', 'v', 'e', 'r', 'y', '_', 'l', 'o', 'n', 'g', '_', 'r',
+      'e', 'p', 'o', 'r', 't', '_', 'd', 'a', 't', 'a', '_', 's', 't',
+      'r', 'i', 'n', 'g', '_', 'w', 'h', 'i', 'c', 'h', '_', 'i', 's',
+      '_', 's', 'o', '_', 'l', 'o', 'n', 'g', '_', 't', 'h', 'a', 't',
+      '_', 'i', 't', '_', 'e', 'x', 'c', 'e', 'e', 'd', 's', '_',
+  };
+
   std::optional<AttestationReport> attestation_report =
       fetchSnpAttestation(report_data);
+
   EXPECT_TRUE(attestation_report.has_value());
-  EXPECT_EQ(
-    getReportData(attestation_report->evidence),
-    report_data.substr(0, 64)
-  );
+  EXPECT_EQ(getReportData(attestation_report->evidence), expected);
 }
 
 TEST_F(JsonAttestationReportTest, FetchRealAttestationNonSnp) {


### PR DESCRIPTION
Closes https://github.com/microsoft/privacy-sandbox-dev/issues/251

Expands the existing tests which previously only checked that `fetchSnpAttestation()` returned \*something\* for three cases:
- No `report_data` provided (defaults to "")
- `report_data` which is under 64 bytes is provided, providing coverage that we properly zero out the report_data field 
- `report_data` which is over 64 bytes is provided, providing coverage that we properly truncate it.

Now we don't only validate that we get some attestation, we parse out the `report_data` field and confirm it's an exact match with the expected value

Update: we have also made some changes to the implementation being tested to make it more readable